### PR TITLE
Change data source strategy

### DIFF
--- a/.config/.eslintrc
+++ b/.config/.eslintrc
@@ -4,7 +4,7 @@
  * In order to extend the configuration follow the steps in
  * https://grafana.github.io/plugin-tools/docs/advanced-configuration#extending-the-eslint-config
  */
- {
+{
   "extends": ["@grafana/eslint-config"],
   "root": true,
   "rules": {

--- a/.config/.prettierrc.js
+++ b/.config/.prettierrc.js
@@ -5,12 +5,12 @@
  */
 
 module.exports = {
-  "endOfLine": "auto",
-  "printWidth": 120,
-  "trailingComma": "es5",
-  "semi": true,
-  "jsxSingleQuote": false,
-  "singleQuote": true,
-  "useTabs": false,
-  "tabWidth": 2
+  endOfLine: 'auto',
+  printWidth: 120,
+  trailingComma: 'es5',
+  semi: true,
+  jsxSingleQuote: false,
+  singleQuote: true,
+  useTabs: false,
+  tabWidth: 2,
 };

--- a/.config/README.md
+++ b/.config/README.md
@@ -142,7 +142,7 @@ We need to update the `scripts` in the `package.json` to use the extended Webpac
 
 ### Configure grafana image to use when running docker
 
-By default `grafana-enterprise` will be used as the docker image for all docker related commands. If you want to override this behaviour simply alter the `docker-compose.yaml` by adding the following build arg `grafana_image`. 
+By default `grafana-enterprise` will be used as the docker image for all docker related commands. If you want to override this behaviour simply alter the `docker-compose.yaml` by adding the following build arg `grafana_image`.
 
 **Example:**
 

--- a/.config/jest/utils.js
+++ b/.config/jest/utils.js
@@ -24,5 +24,5 @@ const grafanaESModules = [
 
 module.exports = {
   nodeModulesToTransform,
-  grafanaESModules
-}
+  grafanaESModules,
+};

--- a/.config/tsconfig.json
+++ b/.config/tsconfig.json
@@ -4,7 +4,7 @@
  * In order to extend the configuration follow the steps in
  * https://grafana.github.io/plugin-tools/docs/advanced-configuration#extending-the-typescript-config
  */
- {
+{
   "compilerOptions": {
     "alwaysStrict": true,
     "declaration": false,

--- a/.config/webpack/utils.ts
+++ b/.config/webpack/utils.ts
@@ -25,7 +25,8 @@ export function hasReadme() {
 export async function getEntries(): Promise<Record<string, string>> {
   const pluginsJson = await globAsync('**/src/**/plugin.json', { absolute: true });
 
-  const plugins = await Promise.all(pluginsJson.map((pluginJson) => {
+  const plugins = await Promise.all(
+    pluginsJson.map((pluginJson) => {
       const folder = path.dirname(pluginJson);
       return globAsync(`${folder}/module.{ts,tsx,js,jsx}`, { absolute: true });
     })

--- a/.config/webpack/webpack.config.ts
+++ b/.config/webpack/webpack.config.ts
@@ -94,7 +94,7 @@ const config = async (env): Promise<Configuration> => ({
       },
       {
         test: /\.css$/,
-        use: ["style-loader", "css-loader"]
+        use: ['style-loader', 'css-loader'],
       },
       {
         test: /\.s[ac]ss$/,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,25 +1,16 @@
 {
-    "env": {
-        "browser": true,
-        "node": true,
-        "es2021": true
-    },
-    "extends": [
-        "eslint:recommended",
-        "plugin:react/recommended",
-        "plugin:@typescript-eslint/recommended"
-    ],
-    "overrides": [
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": "latest",
-        "sourceType": "module"
-    },
-    "plugins": [
-        "react",
-        "@typescript-eslint"
-    ],
-    "rules": {
-    }
+  "env": {
+    "browser": true,
+    "node": true,
+    "es2021": true
+  },
+  "extends": ["eslint:recommended", "plugin:react/recommended", "plugin:@typescript-eslint/recommended"],
+  "overrides": [],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": ["react", "@typescript-eslint"],
+  "rules": {}
 }

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   // Prettier configuration provided by Grafana scaffolding
-  ...require("./.config/.prettierrc.js")
+  ...require('./.config/.prettierrc.js'),
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.0 Sumo Metrics Plugin 
+## 1.0.0 Sumo Metrics Plugin
 
 - Support for configuring Sumo as data source
 - Query in panels

--- a/GRAFANA_README.md
+++ b/GRAFANA_README.md
@@ -8,7 +8,6 @@ Grafana supports a wide range of data sources, including Prometheus, MySQL, and 
 
 ## Getting started
 
-
 ### Frontend
 
 1. Install dependencies
@@ -34,7 +33,7 @@ Grafana supports a wide range of data sources, including Prometheus, MySQL, and 
    ```bash
    # Runs the tests and watches for changes, requires git init first
    yarn test
-   
+
    # Exists after running all the tests
    yarn test:ci
    ```
@@ -49,12 +48,11 @@ Grafana supports a wide range of data sources, including Prometheus, MySQL, and 
 
    ```bash
    yarn lint
-   
+
    # or
 
    yarn lint:fix
    ```
-
 
 # Distributing your plugin
 
@@ -94,7 +92,6 @@ To trigger the workflow we need to push a version tag to github. This can be ach
 
 1. Run `npm version <major|minor|patch>`
 2. Run `git push origin main --follow-tags`
-
 
 ## Learn more
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ The Grafana backend will proxy all requests from the browser, and send them on t
 
 - [Grafana version support](#grafana-version-support)
 - [Install the plugin](#install-the-plugin)
-    * [Install on Mac](#install-on-mac)
-    * [Install on Ubuntu Linux](#install-on-ubuntu-linux)
+  - [Install on Mac](#install-on-mac)
+  - [Install on Ubuntu Linux](#install-on-ubuntu-linux)
 - [Configure the plugin](#configure-the-plugin)
 - [Query metrics in Grafana](#query-metrics-in-grafana)
 - [Plugin development](#plugin-development)
@@ -55,12 +55,14 @@ To build the beta version, please run following steps:
    ![dash-icon](https://github.com/SumoLogic-Labs/sumologic-grafana-datasource/blob/HEAD/screenshots/basic-auth.png?raw=true)
 
 8. In the **Basic Auth Details** section:
-    - In the **User** field, enter the Access ID you generated in step 1.
-    - In the **Password** field, enter the Access Key you generated in step 1.
+
+   - In the **User** field, enter the Access ID you generated in step 1.
+   - In the **Password** field, enter the Access Key you generated in step 1.
 
 9. If you are using **old Grafana version**, there are few more points need to be taken into account:
-    1. Select **Sumo Logic Metrics** from the **Type** dropdown.
-    2. In the **Access** field, leave "proxy" selected.
+
+   1. Select **Sumo Logic Metrics** from the **Type** dropdown.
+   2. In the **Access** field, leave "proxy" selected.
 
 10. Click **Add** to save the new data source.
 

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -5,28 +5,29 @@ import { DataSourceJsonData, DataSourcePluginOptionsEditorProps } from '@grafana
 export function ConfigEditor({ onOptionsChange, options }: DataSourcePluginOptionsEditorProps) {
   return (
     <div className="gf-form-group">
-      <p>URL should be taken from{' '}
+      <p>
+        URL should be taken from{' '}
         <a
           target="_blank"
           rel="noopener noreferrer"
           href="https://help.sumologic.com/docs/api/getting-started/#sumo-logic-endpoints-by-deployment-and-firewall-security"
         >
           Sumo Logic Endpoints by Deployment and Firewall Security
-        </a>.
+        </a>
+        .
       </p>
       <p>
-        You also need to get <a
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://help.sumologic.com/Manage/Security/Access-Keys"
-        >Access Key</a>.
-        {' '}<strong>Access ID</strong> should be used in the <strong>User</strong> field,
-        and <strong>Access Key</strong> should be passed to the <strong>Password</strong> field.
+        You also need to get{' '}
+        <a target="_blank" rel="noopener noreferrer" href="https://help.sumologic.com/Manage/Security/Access-Keys">
+          Access Key
+        </a>
+        . <strong>Access ID</strong> should be used in the <strong>User</strong> field, and <strong>Access Key</strong>{' '}
+        should be passed to the <strong>Password</strong> field.
       </p>
       {options.access === 'direct' && (
         <Alert title="Browser access" severity="info">
-          In order to ensure that Browser access works as expected, please keep in mind to add the Grafana domain
-          to your Allowlisted CORS Domains in the Sumo Logic Access Key configuration.
+          In order to ensure that Browser access works as expected, please keep in mind to add the Grafana domain to
+          your Allowlisted CORS Domains in the Sumo Logic Access Key configuration.
         </Alert>
       )}
       <DataSourceHttpSettings

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,80 +1,83 @@
 import React, { useMemo } from 'react';
-import { Button, QueryField , Select } from '@grafana/ui';
+import { Button, QueryField, Select } from '@grafana/ui';
 import { QueryEditorProps } from '@grafana/data';
 import { DataSource } from '../datasource';
 import { SumoQuery } from '../types/metricsApi.types';
 import { isLogsQuery, SumoQueryType } from '../types/constants';
- 
+
 type Props = QueryEditorProps<DataSource, SumoQuery>;
 
 const selectOptions = [
   {
-    value : SumoQueryType.LogsAggregate,
-    label : 'Logs: Aggregate'
+    value: SumoQueryType.LogsAggregate,
+    label: 'Logs: Aggregate',
   },
   {
-    value : SumoQueryType.LogsNonAggregate,
-    label : 'Logs: Non-Aggregate'
+    value: SumoQueryType.LogsNonAggregate,
+    label: 'Logs: Non-Aggregate',
   },
   {
-    value : SumoQueryType.Metrics,
-    label : 'Metrics'
-  }
-]
+    value: SumoQueryType.Metrics,
+    label: 'Metrics',
+  },
+];
 
 export function QueryEditor(props: Props) {
+  const { queries, query, onChange, onRunQuery } = props;
 
-  const { queries , query , onChange , onRunQuery} = props
+  const onQueryTextChange = React.useCallback(
+    (changedQueryText: string) => {
+      onChange({ ...query, queryText: changedQueryText });
+    },
+    [query, onChange]
+  );
 
-  const onQueryTextChange = React.useCallback((changedQueryText: string) => {
-    onChange({ ...query, queryText: changedQueryText  });
-  }, [query , onChange]);
+  const { queryText, type, refId } = query;
 
-  const { queryText , type , refId  } = query;
+  const onTypeChangeHandler = React.useCallback(
+    (selectedObj: { value?: SumoQueryType; label?: string }) => {
+      onChange({ ...query, type: selectedObj.value });
+    },
+    [query, onChange]
+  );
 
-  const onTypeChangeHandler = React.useCallback((selectedObj : { value?: SumoQueryType , label? : string })=>{
-    onChange({ ...query, type : selectedObj.value });
-  } , [query , onChange])
-
-
-  const isEditorDisabled = useMemo(()=>{
-
-    if(isLogsQuery(type)){
+  const isEditorDisabled = useMemo(() => {
+    if (isLogsQuery(type)) {
       return false;
     }
     // disable editor is there is any log query present
-    if(queries){
-      const logsQuery = queries.find( (queryObj : SumoQuery) =>isLogsQuery(queryObj.type))
-      return logsQuery ? true : false
+    if (queries) {
+      const logsQuery = queries.find((queryObj: SumoQuery) => isLogsQuery(queryObj.type));
+      return logsQuery ? true : false;
     }
 
-    return false
-  } , [queries , query])
-
+    return false;
+  }, [queries, query]);
 
   return (
     <div style={{ display: 'flex', gap: '1rem' }}>
-      <div style={{width : '175px'}}>
+      <div style={{ width: '175px' }}>
         <Select
           options={selectOptions}
-          value={type  || SumoQueryType.Metrics}
+          value={type || SumoQueryType.Metrics}
           onChange={onTypeChangeHandler}
           disabled={isEditorDisabled}
         />
       </div>
-      
+
       <QueryField
         // if onRunQuery is not passed then you user would not be able to focus out from the QueryField
         onRunQuery={onRunQuery}
         onChange={onQueryTextChange}
-        placeholder= { isLogsQuery(type) ? "Logs Query" : "Metric Query"}
+        placeholder={isLogsQuery(type) ? 'Logs Query' : 'Metric Query'}
         query={queryText || ''}
         portalOrigin="sumo-metrics"
         disabled={isEditorDisabled}
         key={refId + type}
       />
-      <Button disabled={isEditorDisabled} onClick={onRunQuery}>Run</Button>
+      <Button disabled={isEditorDisabled} onClick={onRunQuery}>
+        Run
+      </Button>
     </div>
   );
 }
-

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1,6 +1,6 @@
 import { DataQueryRequest, DataQueryResponse, DataSourceInstanceSettings, TimeRange } from '@grafana/data';
 import { getBackendSrv, getTemplateSrv } from '@grafana/runtime';
-import { of ,firstValueFrom , filter , Observable } from 'rxjs';
+import { of, firstValueFrom, filter, Observable } from 'rxjs';
 
 import { DataSource } from './datasource';
 import { SumoQuery } from './types/metricsApi.types';
@@ -26,7 +26,6 @@ jest.mock('@grafana/runtime', () => {
 });
 
 describe('placeholder test', () => {
-
   function createDataSource() {
     return new DataSource({
       url: 'https://long-api.sumologic.net/api',
@@ -49,23 +48,16 @@ describe('placeholder test', () => {
 
       expect(mockedFetch).toHaveBeenCalledWith({
         method: 'POST',
-        url: 'https://long-api.sumologic.net/api/v1/metadataCatalog/dimensions/metric/values/search',
+        url: 'https://long-api.sumologic.net/api/v1/search/jobs',
         credentials: 'include',
         headers: {
           Authorization: 'authorizationHeaderContent',
         },
         data: {
-          selector: [],
-          term: '',
-          from: {
-            epochMillis: expect.any(Number),
-            type: 'EpochTimeRangeBoundary',
-          },
-          to: {
-            epochMillis: expect.any(Number),
-            type: 'EpochTimeRangeBoundary',
-          },
-          size: 1,
+          byReceiptTime: true,
+          query: '* | count',
+          from: expect.any(Number),
+          to: expect.any(Number),
         },
       });
 
@@ -88,26 +80,27 @@ describe('placeholder test', () => {
     it('should call sumo API and map response', async () => {
       const mockedFetch = getBackendSrv().fetch as jest.Mock;
 
-      mockedFetch.mockReturnValue(of({
-        data: {
-          data: [
-            { value: 'Value 1', count: 0 },
-            { value: 'Value 2', count: 0 },
-          ],
-        },
-      }));
+      mockedFetch.mockReturnValue(
+        of({
+          data: {
+            data: [
+              { value: 'Value 1', count: 0 },
+              { value: 'Value 2', count: 0 },
+            ],
+          },
+        })
+      );
 
-      const result = await createDataSource()
-        .metricFindQuery('metric=cpu', {
-          range: {
-            from: new Date(2022, 7, 1, 13, 30, 0, 0), // in real env Moment instance would be passed
-            to: new Date(2022, 7, 1, 13, 45, 0, 0), // in real env Moment instance would be passed
-          } as unknown as TimeRange,
-          variable: {
-            name: '_source',
-            query: 'metric=cpu',
-          }
-        });
+      const result = await createDataSource().metricFindQuery('metric=cpu', {
+        range: {
+          from: new Date(2022, 7, 1, 13, 30, 0, 0), // in real env Moment instance would be passed
+          to: new Date(2022, 7, 1, 13, 45, 0, 0), // in real env Moment instance would be passed
+        } as unknown as TimeRange,
+        variable: {
+          name: '_source',
+          query: 'metric=cpu',
+        },
+      });
 
       expect(mockedFetch).toHaveBeenCalledWith({
         method: 'POST',
@@ -143,114 +136,133 @@ describe('placeholder test', () => {
         errorInstanceId: null,
         errorKey: null,
         keyedErrors: [],
-        response: [{
-          rowId: 'A',
-          results: [{
-            metric: {
-              name: 'CPUFrequencyMHz_19',
-              dimensions: [{
-                key: '_sourceHost',
-                value: 'us2-tsat-clickhouse-3',
-                legend: true
-              }, { key: 'Role', value: 'tsat-clickhouse', legend: false }, {
-                key: 'metric',
-                value: 'CPUFrequencyMHz_19',
-                legend: true
-              }],
-              algoId: 1,
-              customLabel: ''
-            },
-            horAggs: {
-              min: 2937.0,
-              max: 3100.0,
-              avg: 3095.8098591549297,
-              sum: 1099012.5,
-              count: 355,
-              latest: 3100.0
-            },
-            datapoints: {
-              timestamp: [1677148320000, 1677148380000],
-              value: [3099.0, 3100.0],
-              outlierParams: [{
-                anomalyScore: 0.0,
-                baseline: 0.0,
-                unit: 0.0,
-                lowerBound: 0.0,
-                upperBound: 0.0,
-                isOutlier: false,
-                outlier: false
-              }, {
-                anomalyScore: 0.0,
-                baseline: 0.0,
-                unit: 0.0,
-                lowerBound: 0.0,
-                upperBound: 0.0,
-                isOutlier: false,
-                outlier: false
-              }],
-              max: [3099.0, 3100.0],
-              min: [3099.0, 3100.0],
-              avg: [3099.0, 3100.0],
-              count: [1, 1],
-              isFilled: [false, false]
-            }
-          }, {
-            metric: {
-              name: 'CPUFrequencyMHz_19',
-              dimensions: [{
-                key: '_sourceHost',
-                value: 'us2-tsat-clickhouse-2',
-                legend: true
-              }, { key: 'Role', value: 'tsat-clickhouse', legend: false }, {
-                key: 'metric',
-                value: 'CPUFrequencyMHz_19',
-                legend: true
-              }],
-              algoId: 1,
-              customLabel: ''
-            },
-            horAggs: {
-              min: 2953.0,
-              max: 3100.0,
-              avg: 3094.7897727272725,
-              sum: 1089366.0,
-              count: 352,
-              latest: 3098.0
-            },
-            datapoints: {
-              timestamp: [1677148320000, 1677148380000],
-              value: [3098.0, 3099.0],
-              outlierParams: [{
-                anomalyScore: 0.0,
-                baseline: 0.0,
-                unit: 0.0,
-                lowerBound: 0.0,
-                upperBound: 0.0,
-                isOutlier: false,
-                outlier: false
-              }, {
-                anomalyScore: 0.0,
-                baseline: 0.0,
-                unit: 0.0,
-                lowerBound: 0.0,
-                upperBound: 0.0,
-                isOutlier: false,
-                outlier: false
-              }],
-              max: [3098.0, 3099.0],
-              min: [3098.0, 3099.0],
-              count: [1, 1],
-              isFilled: [false, false]
-            }
-          }]
-        }],
+        response: [
+          {
+            rowId: 'A',
+            results: [
+              {
+                metric: {
+                  name: 'CPUFrequencyMHz_19',
+                  dimensions: [
+                    {
+                      key: '_sourceHost',
+                      value: 'us2-tsat-clickhouse-3',
+                      legend: true,
+                    },
+                    { key: 'Role', value: 'tsat-clickhouse', legend: false },
+                    {
+                      key: 'metric',
+                      value: 'CPUFrequencyMHz_19',
+                      legend: true,
+                    },
+                  ],
+                  algoId: 1,
+                  customLabel: '',
+                },
+                horAggs: {
+                  min: 2937.0,
+                  max: 3100.0,
+                  avg: 3095.8098591549297,
+                  sum: 1099012.5,
+                  count: 355,
+                  latest: 3100.0,
+                },
+                datapoints: {
+                  timestamp: [1677148320000, 1677148380000],
+                  value: [3099.0, 3100.0],
+                  outlierParams: [
+                    {
+                      anomalyScore: 0.0,
+                      baseline: 0.0,
+                      unit: 0.0,
+                      lowerBound: 0.0,
+                      upperBound: 0.0,
+                      isOutlier: false,
+                      outlier: false,
+                    },
+                    {
+                      anomalyScore: 0.0,
+                      baseline: 0.0,
+                      unit: 0.0,
+                      lowerBound: 0.0,
+                      upperBound: 0.0,
+                      isOutlier: false,
+                      outlier: false,
+                    },
+                  ],
+                  max: [3099.0, 3100.0],
+                  min: [3099.0, 3100.0],
+                  avg: [3099.0, 3100.0],
+                  count: [1, 1],
+                  isFilled: [false, false],
+                },
+              },
+              {
+                metric: {
+                  name: 'CPUFrequencyMHz_19',
+                  dimensions: [
+                    {
+                      key: '_sourceHost',
+                      value: 'us2-tsat-clickhouse-2',
+                      legend: true,
+                    },
+                    { key: 'Role', value: 'tsat-clickhouse', legend: false },
+                    {
+                      key: 'metric',
+                      value: 'CPUFrequencyMHz_19',
+                      legend: true,
+                    },
+                  ],
+                  algoId: 1,
+                  customLabel: '',
+                },
+                horAggs: {
+                  min: 2953.0,
+                  max: 3100.0,
+                  avg: 3094.7897727272725,
+                  sum: 1089366.0,
+                  count: 352,
+                  latest: 3098.0,
+                },
+                datapoints: {
+                  timestamp: [1677148320000, 1677148380000],
+                  value: [3098.0, 3099.0],
+                  outlierParams: [
+                    {
+                      anomalyScore: 0.0,
+                      baseline: 0.0,
+                      unit: 0.0,
+                      lowerBound: 0.0,
+                      upperBound: 0.0,
+                      isOutlier: false,
+                      outlier: false,
+                    },
+                    {
+                      anomalyScore: 0.0,
+                      baseline: 0.0,
+                      unit: 0.0,
+                      lowerBound: 0.0,
+                      upperBound: 0.0,
+                      isOutlier: false,
+                      outlier: false,
+                    },
+                  ],
+                  max: [3098.0, 3099.0],
+                  min: [3098.0, 3099.0],
+                  count: [1, 1],
+                  isFilled: [false, false],
+                },
+              },
+            ],
+          },
+        ],
         queryInfo: {
           startTime: 1677148320000,
           endTime: 1677169920000,
           desiredQuantizationInSecs: { empty: false, defined: true },
           actualQuantizationInSecs: 60,
-          sessionIdStr: ''
-        }
+          sessionIdStr: '',
+        },
       };
     };
 
@@ -258,9 +270,11 @@ describe('placeholder test', () => {
       const mockedFetch = getBackendSrv().fetch as jest.Mock;
       const mockedReplace = getTemplateSrv().replace as jest.Mock;
 
-      mockedFetch.mockReturnValue(of({
-        data: queryMockResponse(),
-      }));
+      mockedFetch.mockReturnValue(
+        of({
+          data: queryMockResponse(),
+        })
+      );
 
       const result = await firstValueFrom(
         createDataSource().query({
@@ -270,15 +284,17 @@ describe('placeholder test', () => {
             to: new Date(2022, 7, 1, 13, 45, 0, 0), // in real env Moment instance would be passed
           } as unknown as TimeRange,
           maxDataPoints: 100,
-          targets: [{
-            queryText: 'metric=CPUFrequencyMHz_19',
-            refId: 'A',
-          }],
+          targets: [
+            {
+              queryText: 'metric=CPUFrequencyMHz_19',
+              refId: 'A',
+            },
+          ],
           scopedVars: {
-            test: 'abc'
+            test: 'abc',
           },
         } as unknown as DataQueryRequest<SumoQuery>)
-      ) 
+      );
 
       expect(mockedFetch).toHaveBeenCalledWith({
         method: 'POST',
@@ -288,10 +304,12 @@ describe('placeholder test', () => {
           Authorization: 'authorizationHeaderContent',
         },
         data: {
-          query: [{
-            rowId: 'A',
-            query: 'metric=CPUFrequencyMHz_19'
-          }],
+          query: [
+            {
+              rowId: 'A',
+              query: 'metric=CPUFrequencyMHz_19',
+            },
+          ],
           startTime: 1659360600000,
           endTime: 1659361500000,
           maxDataPoints: 100,
@@ -300,14 +318,13 @@ describe('placeholder test', () => {
         },
       });
 
-      expect(mockedReplace)
-        .toHaveBeenCalledWith(
-          'metric=CPUFrequencyMHz_19',
-          {
-            test: 'abc',
-          },
-          interpolateVariable
-        );
+      expect(mockedReplace).toHaveBeenCalledWith(
+        'metric=CPUFrequencyMHz_19',
+        {
+          test: 'abc',
+        },
+        interpolateVariable
+      );
       expect(result.data.length).toEqual(2);
       expect(result.data[0].name).toEqual('CPUFrequencyMHz_19 _sourceHost=us2-tsat-clickhouse-3');
       expect(result.data[1].name).toEqual('CPUFrequencyMHz_19 _sourceHost=us2-tsat-clickhouse-2');
@@ -317,17 +334,19 @@ describe('placeholder test', () => {
       expect(result.data[1].fields[1].values.toArray()).toEqual([3098.0, 3099.0]);
     });
 
-    it('should handle metrics error', async() => {
+    it('should handle metrics error', async () => {
       const mockedFetch = getBackendSrv().fetch as jest.Mock;
 
-      mockedFetch.mockReturnValue(of({
-        data: {
-          ...queryMockResponse(),
-          error: true,
-          errorMessage: 'API failed',
-          response: [],
-        },
-      }));
+      mockedFetch.mockReturnValue(
+        of({
+          data: {
+            ...queryMockResponse(),
+            error: true,
+            errorMessage: 'API failed',
+            response: [],
+          },
+        })
+      );
 
       try {
         await createDataSource().query({
@@ -352,19 +371,23 @@ describe('placeholder test', () => {
     it('should handle metrics warning', async () => {
       const mockedFetch = getBackendSrv().fetch as jest.Mock;
 
-      mockedFetch.mockReturnValue(of({
-        data: {
-          ...queryMockResponse(),
-          error: true,
-          keyedErrors: [{
-            key: 'error:code',
-            values: {
-              type: 'warning',
-              rowId: 'A',
-            },
-          }],
-        },
-      }));
+      mockedFetch.mockReturnValue(
+        of({
+          data: {
+            ...queryMockResponse(),
+            error: true,
+            keyedErrors: [
+              {
+                key: 'error:code',
+                values: {
+                  type: 'warning',
+                  rowId: 'A',
+                },
+              },
+            ],
+          },
+        })
+      );
 
       const result = await firstValueFrom(
         createDataSource().query({
@@ -374,159 +397,178 @@ describe('placeholder test', () => {
             to: new Date(2022, 7, 1, 13, 45, 0, 0), // in real env Moment instance would be passed
           } as unknown as TimeRange,
           maxDataPoints: 100,
-          targets: [{
-            queryText: 'metric=CPUFrequencyMHz_19',
-            refId: 'A',
-          }],
+          targets: [
+            {
+              queryText: 'metric=CPUFrequencyMHz_19',
+              refId: 'A',
+            },
+          ],
           scopedVars: {},
         } as unknown as DataQueryRequest<SumoQuery>)
-      ) 
+      );
 
-      expect(result.data[0].meta.notices).toEqual([{
-        severity: 'warning',
-        text: 'API return warning with code "error:code"',
-      }]);
+      expect(result.data[0].meta.notices).toEqual([
+        {
+          severity: 'warning',
+          text: 'API return warning with code "error:code"',
+        },
+      ]);
     });
 
     it('should handle metrics warning for multiple queries', async () => {
       const mockedFetch = getBackendSrv().fetch as jest.Mock;
       // const queryMockResponse();
       const mockResponse = queryMockResponse();
-      mockedFetch.mockReturnValue(of({
-        data: {
-          ...mockResponse,
-          error: true,
-          keyedErrors: [{
-            key: 'error:code',
-            values: {
-              type: 'warning',
-              rowId: 'B',
-            },
-          }],
-          response: [
-            mockResponse.response[0],
+      mockedFetch.mockReturnValue(
+        of({
+          data: {
+            ...mockResponse,
+            error: true,
+            keyedErrors: [
+              {
+                key: 'error:code',
+                values: {
+                  type: 'warning',
+                  rowId: 'B',
+                },
+              },
+            ],
+            response: [
+              mockResponse.response[0],
+              {
+                rowId: 'B',
+                results: [],
+              },
+            ],
+          },
+        })
+      );
+
+      const result = await firstValueFrom(
+        createDataSource().query({
+          interval: '6h',
+          range: {
+            from: new Date(2022, 7, 1, 13, 30, 0, 0), // in real env Moment instance would be passed
+            to: new Date(2022, 7, 1, 13, 45, 0, 0), // in real env Moment instance would be passed
+          } as unknown as TimeRange,
+          maxDataPoints: 100,
+          targets: [
             {
-              rowId: 'B',
-              results: [],
+              queryText: 'metric=CPUFrequencyMHz_19',
+              refId: 'A',
+            },
+            {
+              queryText: '/',
+              refId: 'B',
             },
           ],
-        },
-      }));
+          scopedVars: {},
+        } as unknown as DataQueryRequest<SumoQuery>)
+      );
 
-      const result = await firstValueFrom(createDataSource().query({
-        interval: '6h',
-        range: {
-          from: new Date(2022, 7, 1, 13, 30, 0, 0), // in real env Moment instance would be passed
-          to: new Date(2022, 7, 1, 13, 45, 0, 0), // in real env Moment instance would be passed
-        } as unknown as TimeRange,
-        maxDataPoints: 100,
-        targets: [{
-          queryText: 'metric=CPUFrequencyMHz_19',
-          refId: 'A',
-        }, {
-          queryText: '/',
-          refId: 'B',
-        }],
-        scopedVars: {},
-      } as unknown as DataQueryRequest<SumoQuery>));
-      
       expect(result.data[0].meta.notices).toEqual([]);
       expect(result.data[1].meta.notices).toEqual([]);
-      expect(result.data[2].meta.notices).toEqual([{
-        severity: 'warning',
-        text: 'Row B: API return warning with code "error:code"',
-      }]);
+      expect(result.data[2].meta.notices).toEqual([
+        {
+          severity: 'warning',
+          text: 'Row B: API return warning with code "error:code"',
+        },
+      ]);
     });
   });
 
-  describe('query - Logs' , () => {
-
+  describe('query - Logs', () => {
     const dummuySearchQueryId = 'dummyId';
 
-    const url = 'https://long-api.sumologic.net/api/v1/search/jobs'
+    const url = 'https://long-api.sumologic.net/api/v1/search/jobs';
 
-    const range= {
+    const range = {
       from: Date.now(), // in real env Moment instance would be passed
       to: Date.now(), // in real env Moment instance would be passed
-    }
+    };
 
     const createQueryResponse = {
-      id: dummuySearchQueryId
-    }
+      id: dummuySearchQueryId,
+    };
 
     const statusResponse = {
-      state: "DONE GATHERING RESULTS",
+      state: 'DONE GATHERING RESULTS',
       messageCount: 1,
       recordCount: 1,
       pendingWarnings: [],
       pendingErrors: [],
-      histogramBuckets : [{
-        startTimestamp: 1687201200000,
-        length: 2700000,
-        count: 502
-    }],
-    }
+      histogramBuckets: [
+        {
+          startTimestamp: 1687201200000,
+          length: 2700000,
+          count: 502,
+        },
+      ],
+    };
 
-
-    const getLogsResponseObj = (isAggregate = false)=>{
-
+    const getLogsResponseObj = (isAggregate = false) => {
       const commonRecords = [
         {
           map: {
-            _count: "100",
-          }
-        }
-      ]
+            _count: '100',
+          },
+        },
+      ];
       return {
         fields: [
           {
-            name: "_count",
-            fieldType: "int",
-            keyField: false
-          }
+            name: '_count',
+            fieldType: 'int',
+            keyField: false,
+          },
         ],
-        ...(isAggregate ? { records : commonRecords } : { messages : commonRecords })
-      }
-
-    }
+        ...(isAggregate ? { records: commonRecords } : { messages: commonRecords }),
+      };
+    };
 
     const expectedCreatePostRequest = {
-      url : url,
-      data : {
+      url: url,
+      data: {
         query: 'error',
         from: range.from,
         to: range.to,
-        byReceiptTime: true
-      }
-    }
+        byReceiptTime: true,
+      },
+    };
 
-    const getQuery = (isAggregate = false)=>{
+    const getQuery = (isAggregate = false) => {
       return {
         interval: '-5m',
         range: range as unknown as TimeRange,
         maxDataPoints: 100,
-        targets: [{
-          queryText: 'error',
-          refId: 'A',
-          type : isAggregate ? 'LogsAggregate' : 'LogsNonAggregate'
-        }, {
-          queryText: '/', // this will be ignored
-          refId: 'B',
-        }],
+        targets: [
+          {
+            queryText: 'error',
+            refId: 'A',
+            type: isAggregate ? 'LogsAggregate' : 'LogsNonAggregate',
+          },
+          {
+            queryText: '/', // this will be ignored
+            refId: 'B',
+          },
+        ],
         scopedVars: {},
-      }
-    }
+      };
+    };
 
-    const assertDataFrame = (result : DataQueryResponse , isAggregate = false)=>{
+    const assertDataFrame = (result: DataQueryResponse, isAggregate = false) => {
       expect(result.data[0].fields[0].name).toBe('_count');
       expect(result.data[0].fields[0].values.buffer[0]).toBe(100);
-      
-      if(!isAggregate){
-        expect(result.data[0].meta).toEqual({preferredVisualisationType : 'logs'});
-      }
-    }
 
-    const assertHistogramVolumnsData = (result: DataQueryResponse, { minTime, maxTime, count }: { minTime: number, maxTime: number, count: number }) => {
+      if (!isAggregate) {
+        expect(result.data[0].meta).toEqual({ preferredVisualisationType: 'logs' });
+      }
+    };
+
+    const assertHistogramVolumnsData = (
+      result: DataQueryResponse,
+      { minTime, maxTime, count }: { minTime: number; maxTime: number; count: number }
+    ) => {
       expect(result.data[0].name).toBe('logsVolumn');
 
       expect(result.data[0].fields[0].name).toBe('MinBucket');
@@ -537,83 +579,98 @@ describe('placeholder test', () => {
 
       expect(result.data[0].fields[2].name).toBe('count');
       expect(result.data[0].fields[2].values.buffer[0]).toBe(count);
+    };
 
-
-    }
-
-
-    it('should able to fetch logs aggregate query' , async()=>{
-
+    it('should able to fetch logs aggregate query', async () => {
       const mockedFetch = getBackendSrv().fetch as jest.Mock;
 
       mockedFetch
-      .mockReturnValueOnce(of({
-        data: createQueryResponse
-      }))
-      .mockReturnValueOnce(of({
-        data : statusResponse
-      }))
-      .mockReturnValueOnce(of({
-        data : getLogsResponseObj(true)
-      }))
+        .mockReturnValueOnce(
+          of({
+            data: createQueryResponse,
+          })
+        )
+        .mockReturnValueOnce(
+          of({
+            data: statusResponse,
+          })
+        )
+        .mockReturnValueOnce(
+          of({
+            data: getLogsResponseObj(true),
+          })
+        );
 
-      const result = await firstValueFrom(createDataSource().query(getQuery(true) as unknown as DataQueryRequest<SumoQuery>)
-      .pipe(filter((response : any)=>response.data.length > 0))
+      const result = await firstValueFrom(
+        createDataSource()
+          .query(getQuery(true) as unknown as DataQueryRequest<SumoQuery>)
+          .pipe(filter((response: any) => response.data.length > 0))
       );
-
 
       const createRequestObj = mockedFetch.mock.calls[0][0];
       expect(createRequestObj.url).toBe(expectedCreatePostRequest.url);
       expect(createRequestObj.data).toEqual(expectedCreatePostRequest.data);
 
       const statusRequestObj = mockedFetch.mock.calls[1][0];
-      expect(statusRequestObj.url).toBe(`${url}/${dummuySearchQueryId}`)
+      expect(statusRequestObj.url).toBe(`${url}/${dummuySearchQueryId}`);
 
       const recordsRequest = mockedFetch.mock.calls[2][0];
-      expect(recordsRequest.url).toBe(`${url}/${dummuySearchQueryId}/records`)
+      expect(recordsRequest.url).toBe(`${url}/${dummuySearchQueryId}/records`);
 
-      assertDataFrame(result , true);
+      assertDataFrame(result, true);
+    });
 
-    })
-
-
-    it('should able to fetch logs non aggregate query' , async()=>{
-
+    it('should able to fetch logs non aggregate query', async () => {
       const mockedFetch = getBackendSrv().fetch as jest.Mock;
 
       mockedFetch
-      .mockReturnValueOnce(of({
-        data: createQueryResponse
-      }))
-      .mockReturnValueOnce(of({
-        data : statusResponse
-      }))
-      .mockReturnValueOnce(of({
-        data : getLogsResponseObj()
-      }))
-
+        .mockReturnValueOnce(
+          of({
+            data: createQueryResponse,
+          })
+        )
+        .mockReturnValueOnce(
+          of({
+            data: statusResponse,
+          })
+        )
+        .mockReturnValueOnce(
+          of({
+            data: getLogsResponseObj(),
+          })
+        );
 
       const dataSource = createDataSource();
 
-      const queryPromise =  firstValueFrom(dataSource.query(getQuery() as unknown as DataQueryRequest<SumoQuery>)
-      .pipe(filter((response : DataQueryResponse)=>response.data.length > 0)));
+      const queryPromise = firstValueFrom(
+        dataSource
+          .query(getQuery() as unknown as DataQueryRequest<SumoQuery>)
+          .pipe(filter((response: DataQueryResponse) => response.data.length > 0))
+      );
 
-      const histogramDataPromise = firstValueFrom((dataSource.getLogsVolumeDataProvider() as Observable<DataQueryResponse>).pipe(filter((response : DataQueryResponse)=>response.data.length > 0)))
+      const histogramDataPromise = firstValueFrom(
+        (dataSource.getLogsVolumeDataProvider() as Observable<DataQueryResponse>).pipe(
+          filter((response: DataQueryResponse) => response.data.length > 0)
+        )
+      );
 
-      const [queryResult , histogramResult] = await Promise.all([ queryPromise, histogramDataPromise ]) 
+      const [queryResult, histogramResult] = await Promise.all([queryPromise, histogramDataPromise]);
 
       const createRequestObj = mockedFetch.mock.calls[0][0];
       expect(createRequestObj.url).toBe(expectedCreatePostRequest.url);
       expect(createRequestObj.data).toEqual(expectedCreatePostRequest.data);
 
       const statusRequestObj = mockedFetch.mock.calls[1][0];
-      expect(statusRequestObj.url).toBe(`${url}/${dummuySearchQueryId}`)
+      expect(statusRequestObj.url).toBe(`${url}/${dummuySearchQueryId}`);
 
       const recordsRequest = mockedFetch.mock.calls[2][0];
-      expect(recordsRequest.url).toBe(`${url}/${dummuySearchQueryId}/messages`)
-      assertDataFrame(queryResult)
-      assertHistogramVolumnsData(histogramResult , { minTime : 1687201200000 , maxTime : 1687201200000 + 2700000, count : 502 })
-    })
-
-  })
+      expect(recordsRequest.url).toBe(`${url}/${dummuySearchQueryId}/messages`);
+      assertDataFrame(queryResult);
+      assertHistogramVolumnsData(histogramResult, {
+        minTime: 1687201200000,
+        maxTime: 1687201200000 + 2700000,
+        count: 502,
+      });
+    });
+  });
 });

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,16 +1,18 @@
 import {
+  CoreApp,
   DataQueryRequest,
   DataQueryResponse,
   DataSourceApi,
   DataSourceInstanceSettings,
-  MutableDataFrame,
-  FieldType,
-  TimeRange,
   DataSourceWithLogsVolumeSupport,
+  dateTime,
+  FieldType,
   LoadingState,
+  MutableDataFrame,
+  TimeRange,
 } from '@grafana/data';
 import { getBackendSrv, getTemplateSrv } from '@grafana/runtime';
-import { lastValueFrom , Observable , Subject , of , from , map , startWith  } from 'rxjs';
+import { firstValueFrom, from, lastValueFrom, map, Observable, of, startWith, Subject, skip } from 'rxjs';
 import { calculateInterval, createEpochTimeRangeBoundary } from './utils/time.utils';
 import { SumoApiDimensionValuesResponse } from './types/metadataCatalogApi.types';
 import { mapKeyedErrorMessage } from './utils/keyedErrors.utils';
@@ -20,163 +22,164 @@ import { interpolateVariable } from './utils/interpolation.utils';
 
 import { isLogsQuery, SumoQueryType } from './types/constants';
 import { searchQueryExecutionService } from './services/logDataService/searchQueryExecutionService';
-import { MAX_NUMBER_OF_RECORDS, RunSearchActionType, SearchQueryType, SearchStatus } from './services/logDataService/constants';
+import {
+  MAX_NUMBER_OF_RECORDS,
+  RunSearchActionType,
+  SearchQueryType,
+  SearchStatus,
+} from './services/logDataService/constants';
 import { ISearchStatus, RunSearchAction, SearchQueryParams, SearchResult } from './services/logDataService/types';
 
-import { generateAggregateResponse, generateFullRangeHistogram, generateNonAggregateResponse, IPreviousCount, searchFilterForAggregateQuery, searchFilterForNonAggregateQuery } from './services/logDataService/logSearch.utils';
+import {
+  generateAggregateResponse,
+  generateFullRangeHistogram,
+  generateNonAggregateResponse,
+  IPreviousCount,
+  searchFilterForAggregateQuery,
+  searchFilterForNonAggregateQuery,
+} from './services/logDataService/logSearch.utils';
 
-export class DataSource extends DataSourceApi<SumoQuery> 
-implements DataSourceWithLogsVolumeSupport<SumoQuery>
-//todo ssharma:  replace DataSourceWithLogsVolumeSupport with DataSourceWithSupplementaryQueriesSupport with new version of grafana dependency
-{
+export class DataSource extends DataSourceApi<SumoQuery> implements DataSourceWithLogsVolumeSupport<SumoQuery> {
+  //todo ssharma:  replace DataSourceWithLogsVolumeSupport with DataSourceWithSupplementaryQueriesSupport with new version of grafana dependency
   private readonly baseUrl: string;
   private readonly basicAuth: string;
 
-  private logsController$ :  Subject<RunSearchAction> | null
+  private logsController$: Subject<RunSearchAction> | null;
 
-  private logsVolumnsProvider$ : Subject<SearchResult> | null
+  private logsVolumnsProvider$: Subject<SearchResult> | null;
 
   constructor(instanceSettings: DataSourceInstanceSettings) {
     super(instanceSettings);
     this.baseUrl = instanceSettings.url as string;
     this.basicAuth = instanceSettings.basicAuth as string;
-    this.logsController$ = null
-    this.logsVolumnsProvider$ = null
+    this.logsController$ = null;
+    this.logsVolumnsProvider$ = null;
   }
 
   // perform logs/metrics query by Grafana
   query(options: DataQueryRequest<SumoQuery>): Observable<DataQueryResponse> {
-    const { range , targets } = options;
+    const { range, targets } = options;
 
     if (!range) {
       throw new Error('No range has been provided');
     }
-    if(this.logsController$){
+    if (this.logsController$) {
       // stop previous running logs query
-      this.logsController$.next({ type : RunSearchActionType.STOP })
+      this.logsController$.next({ type: RunSearchActionType.STOP });
       this.logsController$ = null;
     }
     this.logsVolumnsProvider$ = null;
 
     //Check if any logs query present
-    const isLogsQueryType = targets.find(query=> isLogsQuery(query.type))
+    const isLogsQueryType = targets.find((query) => isLogsQuery(query.type));
 
-    if(isLogsQueryType){
+    if (isLogsQueryType) {
       return this.fetchLogsQuery(options);
-    }
-    else{
+    } else {
       return this.fetchMetricsQuery(options);
     }
   }
 
-  getLogsVolumeDataProvider(): Observable<DataQueryResponse> | undefined{
-    if(this.logsVolumnsProvider$){
-      return this.logsVolumnsProvider$.asObservable()
-      .pipe(map(response=>{
-        const dataFrame = generateFullRangeHistogram(response.status)
-        return {
-          data : [dataFrame],
-          state : LoadingState.Done
-        }
-      }))
-    } 
-    return 
+  getLogsVolumeDataProvider(): Observable<DataQueryResponse> | undefined {
+    if (this.logsVolumnsProvider$) {
+      return this.logsVolumnsProvider$.asObservable().pipe(
+        map((response) => {
+          const dataFrame = generateFullRangeHistogram(response.status);
+          return {
+            data: [dataFrame],
+            state: LoadingState.Done,
+          };
+        })
+      );
+    }
+    return;
   }
 
-
-  fetchLogsQuery(options: DataQueryRequest<SumoQuery>) : Observable<DataQueryResponse>{
-
-    const { targets, range , scopedVars , maxDataPoints } = options;
+  fetchLogsQuery(options: DataQueryRequest<SumoQuery>): Observable<DataQueryResponse> {
+    const { targets, range, scopedVars, maxDataPoints } = options;
 
     const templateSrv = getTemplateSrv();
 
-    const modifiedQueries : SumoQuery[] = targets
-    .filter(({ queryText }) => Boolean(queryText))
-    .map((query) => ({
-      ...query,
-      queryText: templateSrv.replace(query.queryText as string, scopedVars, interpolateVariable),
-    }));
+    const modifiedQueries: SumoQuery[] = targets
+      .filter(({ queryText }) => Boolean(queryText))
+      .map((query) => ({
+        ...query,
+        queryText: templateSrv.replace(query.queryText as string, scopedVars, interpolateVariable),
+      }));
 
-
-    const logsQueryObj  = modifiedQueries.find(query=>isLogsQuery(query.type))
+    const logsQueryObj = modifiedQueries.find((query) => isLogsQuery(query.type));
 
     if (!logsQueryObj) {
-      return of({ data : []})
+      return of({ data: [] });
     }
 
-    const maxRecords = Math.min(maxDataPoints || MAX_NUMBER_OF_RECORDS , MAX_NUMBER_OF_RECORDS )
+    const maxRecords = Math.min(maxDataPoints || MAX_NUMBER_OF_RECORDS, MAX_NUMBER_OF_RECORDS);
 
     const startTime = range.from.valueOf();
     const endTime = range.to.valueOf();
-    const { queryText , type } = logsQueryObj 
+    const { queryText, type } = logsQueryObj;
     const searchType = type === SumoQueryType.LogsAggregate ? SearchQueryType.AGGREGATE : SearchQueryType.MESSAGES;
 
-    const searchParams : SearchQueryParams = {
+    const searchParams: SearchQueryParams = {
       types: [searchType],
       query: queryText || '',
-      startTime : startTime,
-      endTime : endTime,
-      baseUrl : this.baseUrl,
-      basicAuth : this.basicAuth, 
-      paginationInfo : {
-        offset : 0,
-        length : maxRecords 
-      }
-    }
-    const previousCountMap : IPreviousCount = {
-      statusMessageCount : 0, // message count in status api
-      actualMessageCount : 0  // messages count in message api
-
-    }
+      startTime: startTime,
+      endTime: endTime,
+      baseUrl: this.baseUrl,
+      basicAuth: this.basicAuth,
+      paginationInfo: {
+        offset: 0,
+        length: maxRecords,
+      },
+    };
+    const previousCountMap: IPreviousCount = {
+      statusMessageCount: 0, // message count in status api
+      actualMessageCount: 0, // messages count in message api
+    };
 
     const searchStatusFilter = (status$: Observable<ISearchStatus>) => {
       // filters are used to fetch records and messages
-      return searchType === SearchQueryType.AGGREGATE ?
-        searchFilterForAggregateQuery(status$, previousCountMap) :
-        searchFilterForNonAggregateQuery(status$, maxRecords, previousCountMap);
-    }
+      return searchType === SearchQueryType.AGGREGATE
+        ? searchFilterForAggregateQuery(status$, previousCountMap)
+        : searchFilterForNonAggregateQuery(status$, maxRecords, previousCountMap);
+    };
 
     this.logsController$ = new Subject();
-    if(searchType === SearchQueryType.MESSAGES){
+    if (searchType === SearchQueryType.MESSAGES) {
       this.logsVolumnsProvider$ = new Subject();
     }
 
-    return searchQueryExecutionService.run(
-      searchParams,
-      this.logsController$,
-      searchStatusFilter
-    ).pipe( 
-      map(response => {
+    return searchQueryExecutionService.run(searchParams, this.logsController$, searchStatusFilter).pipe(
+      map((response) => {
         // update log exploror histogram
-        if(searchType === SearchQueryType.MESSAGES){
-          this.logsVolumnsProvider$?.next(response)
+        if (searchType === SearchQueryType.MESSAGES) {
+          this.logsVolumnsProvider$?.next(response);
         }
         const responseObj = response[searchType];
         const status = response.status;
         if (!responseObj) {
           return {
             data: [],
-            state : LoadingState.Loading
-          }
+            state: LoadingState.Loading,
+          };
         }
-        let dataFrame : MutableDataFrame; 
-        if(searchType === SearchQueryType.AGGREGATE){
+        let dataFrame: MutableDataFrame;
+        if (searchType === SearchQueryType.AGGREGATE) {
           dataFrame = generateAggregateResponse(response);
-        }else{
-          dataFrame = generateNonAggregateResponse(response, previousCountMap)
+        } else {
+          dataFrame = generateNonAggregateResponse(response, previousCountMap);
         }
 
-        return { data: [dataFrame], 
-          state : status.state === SearchStatus.DONE_GATHERING_RESULTS ?  LoadingState.Done : LoadingState.Loading
-          }
+        return {
+          data: [dataFrame],
+          state: status.state === SearchStatus.DONE_GATHERING_RESULTS ? LoadingState.Done : LoadingState.Loading,
+        };
       }),
-      startWith({ data : [] , state : LoadingState.Loading })
-    )
+      startWith({ data: [], state: LoadingState.Loading })
+    );
   }
 
-
-  fetchMetricsQuery(options: DataQueryRequest<SumoQuery>) : Observable<DataQueryResponse>{
-
+  fetchMetricsQuery(options: DataQueryRequest<SumoQuery>): Observable<DataQueryResponse> {
     const { range, maxDataPoints, targets, scopedVars, interval } = options;
 
     const templateSrv = getTemplateSrv();
@@ -199,78 +202,90 @@ implements DataSourceWithLogsVolumeSupport<SumoQuery>
       }));
 
     if (!queries.length) {
-      return of({ data : []})
+      return of({ data: [] });
     }
 
     const hasMultipleQueries = queries.length > 1;
 
-    return from(this.fetchMetrics(queries, {
-      startTime,
-      endTime,
-      requestedDataPoints,
-      maxDataPoints: maxDataPoints ?? 100,
-      desiredQuantizationInSec,
-    })).pipe(
-      map(res=>{
-        const { data: { response, keyedErrors, error, errorKey, errorMessage } } = res;
+    return from(
+      this.fetchMetrics(queries, {
+        startTime,
+        endTime,
+        requestedDataPoints,
+        maxDataPoints: maxDataPoints ?? 100,
+        desiredQuantizationInSec,
+      })
+    ).pipe(
+      map((res) => {
+        const {
+          data: { response, keyedErrors, error, errorKey, errorMessage },
+        } = res;
         if (error && !response.length) {
           if (errorMessage) {
             throw new Error(errorMessage);
           }
-    
+
           if (errorKey) {
             throw new Error(`API return error with code "${errorKey}"`);
           }
-    
+
           const firstKeyedError = keyedErrors.find((keyedError) => keyedError.values?.type === 'error');
           const firstWarningError = keyedErrors.find((keyedError) => keyedError.values?.type === 'warning');
-    
+
           throw new Error(mapKeyedErrorMessage(firstKeyedError ?? firstWarningError));
         }
-    
+
         const data = response.flatMap(({ rowId, results }) => {
           const responseSpecificErrors = hasMultipleQueries
             ? keyedErrors.filter(({ values }) => values?.rowId === rowId)
             : keyedErrors;
-          const notices = responseSpecificErrors
-            .map(keyedError => ({
-              text: mapKeyedErrorMessage(keyedError, hasMultipleQueries ? rowId : undefined),
-              severity: keyedError.values?.type ?? 'error',
-            }));
+          const notices = responseSpecificErrors.map((keyedError) => ({
+            text: mapKeyedErrorMessage(keyedError, hasMultipleQueries ? rowId : undefined),
+            severity: keyedError.values?.type ?? 'error',
+          }));
           return results.length
-            ? results.map(({ metric, datapoints }) => new MutableDataFrame({
-              name: `${metric.name} ${dimensionsToLabelSuffix(metric.dimensions)}`.trim(),
-              refId: rowId,
-              meta: { notices },
-              fields: [
-                { name: 'Time', values: datapoints.timestamp, type: FieldType.time},
-                { name: 'Value', values: datapoints.value, type: FieldType.number}
-              ]
-            }))
+            ? results.map(
+                ({ metric, datapoints }) =>
+                  new MutableDataFrame({
+                    name: `${metric.name} ${dimensionsToLabelSuffix(metric.dimensions)}`.trim(),
+                    refId: rowId,
+                    meta: { notices },
+                    fields: [
+                      { name: 'Time', values: datapoints.timestamp, type: FieldType.time },
+                      { name: 'Value', values: datapoints.value, type: FieldType.number },
+                    ],
+                  })
+              )
             : new MutableDataFrame({
-              name: `${rowId}`,
-              refId: rowId,
-              meta: { notices, },
-              fields: []
-            });
+                name: `${rowId}`,
+                refId: rowId,
+                meta: { notices },
+                fields: [],
+              });
         });
-        return { data }   
+        return { data };
       })
-    )
+    );
   }
 
   // used to get Query dependent variables by Grafana
-  async metricFindQuery(query: string, { variable: { name }, range }: {
-    range: TimeRange;
-    variable: {
-      name: string;
-      query: string;
-    };
-  }) {
+  async metricFindQuery(
+    query: string,
+    {
+      variable: { name },
+      range,
+    }: {
+      range: TimeRange;
+      variable: {
+        name: string;
+        query: string;
+      };
+    }
+  ) {
     const response = await this.getDimensionValues(name, {
       query,
       from: range.from.valueOf(),
-      to: range.to.valueOf()
+      to: range.to.valueOf(),
     });
 
     return response.data.data.map(({ value }) => ({ text: value }));
@@ -278,12 +293,34 @@ implements DataSourceWithLogsVolumeSupport<SumoQuery>
 
   // used to check if plugin configured properly by Grafana
   testDatasource() {
-    return this.getDimensionValues('metric', {
-        size: 1,
-        from: Date.now() - 60 * 1000,
-        to: Date.now()
-      })
-      .catch(err => {
+    return firstValueFrom(
+      this.query({
+        requestId: 'test-request',
+        scopedVars: {},
+        interval: '15m',
+        intervalMs: 15 * 60 * 1000,
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        app: CoreApp.Unknown,
+        startTime: Date.now() - 15 * 60 * 1000,
+        maxDataPoints: 1,
+        targets: [
+          {
+            type: SumoQueryType.LogsAggregate,
+            queryText: '* | count',
+            refId: 'A',
+          },
+        ],
+        range: {
+          from: dateTime(Date.now() - 15 * 60 * 1000),
+          to: dateTime(new Date()),
+          raw: {
+            from: dateTime(Date.now() - 15 * 60 * 1000),
+            to: dateTime(new Date()),
+          },
+        },
+      }).pipe(skip(1))
+    )
+      .catch((err) => {
         if (err.status === 404) {
           if (!this.baseUrl.endsWith('/api/')) {
             return Promise.reject(new Error('API returns 404. Please ensure that provided URL contain full path.'));
@@ -298,12 +335,20 @@ implements DataSourceWithLogsVolumeSupport<SumoQuery>
       }));
   }
 
-  private getDimensionValues(term: string, { query, from, to, size = 1000 }: {
-    query?: string;
-    from: number;
-    to: number;
-    size?: number;
-  }) {
+  private getDimensionValues(
+    term: string,
+    {
+      query,
+      from,
+      to,
+      size = 1000,
+    }: {
+      query?: string;
+      from: number;
+      to: number;
+      size?: number;
+    }
+  ) {
     return this.sumoApiRequest<SumoApiDimensionValuesResponse>({
       url: `/v1/metadataCatalog/dimensions/${encodeURIComponent(term)}/values/search`,
       data: {
@@ -313,14 +358,13 @@ implements DataSourceWithLogsVolumeSupport<SumoQuery>
         to: createEpochTimeRangeBoundary(to),
         size,
       },
-    })
-      .catch(err => {
-        if (Array.isArray(err.data?.errors)) {
-          return Promise.reject(new Error(err.data?.errors[0].message));
-        }
+    }).catch((err) => {
+      if (Array.isArray(err.data?.errors)) {
+        return Promise.reject(new Error(err.data?.errors[0].message));
+      }
 
-        return Promise.reject(err);
-      });
+      return Promise.reject(err);
+    });
   }
 
   private fetchMetrics(
@@ -330,7 +374,7 @@ implements DataSourceWithLogsVolumeSupport<SumoQuery>
       endTime,
       maxDataPoints,
       requestedDataPoints,
-      desiredQuantizationInSec
+      desiredQuantizationInSec,
     }: {
       startTime: number;
       endTime: number;
@@ -352,19 +396,25 @@ implements DataSourceWithLogsVolumeSupport<SumoQuery>
     });
   }
 
-  private sumoApiRequest<Response>({ url, method = 'POST', data }: {
+  private sumoApiRequest<Response>({
+    url,
+    method = 'POST',
+    data,
+  }: {
     method?: 'POST' | 'GET';
     url: string;
     data?: unknown;
   }) {
-    return lastValueFrom(getBackendSrv().fetch<Response>({
-      method,
-      credentials: 'include',
-      headers: {
-        Authorization: this.basicAuth,
-      },
-      url: this.baseUrl + url,
-      data,
-    }));
+    return lastValueFrom(
+      getBackendSrv().fetch<Response>({
+        method,
+        credentials: 'include',
+        headers: {
+          Authorization: this.basicAuth,
+        },
+        url: this.baseUrl + url,
+        data,
+      })
+    );
   }
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -6,4 +6,4 @@ import { SumoQuery } from './types/metricsApi.types';
 
 export const plugin = new DataSourcePlugin<DataSource, SumoQuery>(DataSource)
   .setConfigEditor(ConfigEditor)
-  .setQueryEditor(QueryEditor)
+  .setQueryEditor(QueryEditor);

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -17,8 +17,11 @@
       "large": "img/logo.png"
     },
     "links": [
-      {"name": "Project site", "url": "https://github.com/SumoLogic-Labs/sumologic-grafana-datasource"},
-      {"name": "Apache License", "url": "https://github.com/SumoLogic-Labs/sumologic-grafana-datasource/blob/HEAD/LICENSE"}
+      { "name": "Project site", "url": "https://github.com/SumoLogic-Labs/sumologic-grafana-datasource" },
+      {
+        "name": "Apache License",
+        "url": "https://github.com/SumoLogic-Labs/sumologic-grafana-datasource/blob/HEAD/LICENSE"
+      }
     ],
     "screenshots": [],
     "version": "1.0.0",

--- a/src/services/logDataService/constants.ts
+++ b/src/services/logDataService/constants.ts
@@ -1,33 +1,30 @@
-
-
 export enum RunSearchActionType {
-    SET_PAGE = 'Page',
-    PAUSE = 'Pause',
-    STOP = 'Stop',
-  }
-
-export enum SearchStatus {
-    NOT_STARTED = 'NOT STARTED',
-    GATHERING_RESULTS = 'GATHERING RESULTS',
-    FORCE_PAUSED = 'FORCE PAUSED',
-    DONE_GATHERING_RESULTS = 'DONE GATHERING RESULTS',
-    CANCELLED = 'CANCELLED',
+  SET_PAGE = 'Page',
+  PAUSE = 'Pause',
+  STOP = 'Stop',
 }
 
-export const QUERY_STOPPED_STATES : any = {
-    [SearchStatus.DONE_GATHERING_RESULTS]: true,
-    [SearchStatus.CANCELLED]: true,
-    [SearchStatus.FORCE_PAUSED]: true,
+export enum SearchStatus {
+  NOT_STARTED = 'NOT STARTED',
+  GATHERING_RESULTS = 'GATHERING RESULTS',
+  FORCE_PAUSED = 'FORCE PAUSED',
+  DONE_GATHERING_RESULTS = 'DONE GATHERING RESULTS',
+  CANCELLED = 'CANCELLED',
+}
+
+export const QUERY_STOPPED_STATES: any = {
+  [SearchStatus.DONE_GATHERING_RESULTS]: true,
+  [SearchStatus.CANCELLED]: true,
+  [SearchStatus.FORCE_PAUSED]: true,
 };
 
 export enum SearchQueryType {
-    MESSAGES = 'message',
-    AGGREGATE = 'aggregate',
-  }
+  MESSAGES = 'message',
+  AGGREGATE = 'aggregate',
+}
 
-  
 export const MESSAGES_RETRY_COUNT = 100;
 export const MESSAGES_RETRY_DELAY = 3000;
 export const MESSAGES_RETRY_EMPTY_ERROR = 'MESSAGES_RETRY_EMPTY_ERROR';
 
-export const MAX_NUMBER_OF_RECORDS = 10000
+export const MAX_NUMBER_OF_RECORDS = 10000;

--- a/src/services/logDataService/logSearch.utils.ts
+++ b/src/services/logDataService/logSearch.utils.ts
@@ -1,55 +1,63 @@
-import { IField, ISearchAggregateResult, ISearchMessageResult, ISearchStatus, SearchResult } from "./types";
+import { IField, ISearchAggregateResult, ISearchMessageResult, ISearchStatus, SearchResult } from './types';
 import { Observable, filter } from 'rxjs';
-import { SearchStatus } from "./constants";
-import { FieldType, MutableDataFrame } from "@grafana/data";
-import { formatSumoValues, getNonAggregateFieldName, getSumoToGrafanaType } from "../../types/constants";
-
+import { SearchStatus } from './constants';
+import { FieldType, MutableDataFrame } from '@grafana/data';
+import { formatSumoValues, getNonAggregateFieldName, getSumoToGrafanaType } from '../../types/constants';
 
 export interface IPreviousCount {
-  statusMessageCount: number,
+  statusMessageCount: number;
   // messages count in status api can be different from messages api
-  actualMessageCount: number
+  actualMessageCount: number;
 }
 
 export const searchFilterForAggregateQuery = (status$: Observable<ISearchStatus>, previousCountMap: IPreviousCount) =>
   status$.pipe(
     filter((searchStatusResponse: ISearchStatus) => {
-      const isMessageCountUpdated = searchStatusResponse.messageCount && searchStatusResponse.messageCount > previousCountMap.statusMessageCount ? true : false;
+      const isMessageCountUpdated =
+        searchStatusResponse.messageCount && searchStatusResponse.messageCount > previousCountMap.statusMessageCount
+          ? true
+          : false;
 
       if (isMessageCountUpdated) {
-        previousCountMap.statusMessageCount = searchStatusResponse.messageCount as number
+        previousCountMap.statusMessageCount = searchStatusResponse.messageCount as number;
       }
       const isQueryCompleted = searchStatusResponse.state === SearchStatus.DONE_GATHERING_RESULTS;
 
       return (
         //fetching records when messages count changes and when query gets completed
-        (isMessageCountUpdated || isQueryCompleted)
+        isMessageCountUpdated || isQueryCompleted
       );
-    }),
+    })
   );
 
+export const searchFilterForNonAggregateQuery = (
+  status$: Observable<ISearchStatus>,
+  maxRecords: number,
+  previousCountMap: IPreviousCount
+) =>
+  status$.pipe(
+    filter((searchStatusResponse: ISearchStatus) => {
+      const isMessageCountUpdated =
+        searchStatusResponse.messageCount && searchStatusResponse.messageCount > previousCountMap.statusMessageCount
+          ? true
+          : false;
 
-export const searchFilterForNonAggregateQuery = (status$: Observable<ISearchStatus>, maxRecords: number, previousCountMap: IPreviousCount) => status$.pipe(
-  filter((searchStatusResponse: ISearchStatus) => {
-    const isMessageCountUpdated = searchStatusResponse.messageCount && searchStatusResponse.messageCount > previousCountMap.statusMessageCount ? true : false;
+      const isMessagesLimitCountReached = previousCountMap.actualMessageCount >= maxRecords; // grafana messages maxRecords
 
-    const isMessagesLimitCountReached = previousCountMap.actualMessageCount >= maxRecords; // grafana messages maxRecords
+      if (isMessageCountUpdated) {
+        previousCountMap.statusMessageCount = searchStatusResponse.messageCount as number;
+      }
+      const isQueryCompleted = searchStatusResponse.state === SearchStatus.DONE_GATHERING_RESULTS;
 
-    if (isMessageCountUpdated) {
-      previousCountMap.statusMessageCount = searchStatusResponse.messageCount as number
-    }
-    const isQueryCompleted = searchStatusResponse.state === SearchStatus.DONE_GATHERING_RESULTS;
-
-    return (
-      !(isMessagesLimitCountReached) || isQueryCompleted // no need to fetch further messages once limit reached for non aggergate messages
-    );
-  }),
-);
-
+      return (
+        !isMessagesLimitCountReached || isQueryCompleted // no need to fetch further messages once limit reached for non aggergate messages
+      );
+    })
+  );
 
 export const generateAggregateResponse = (response: SearchResult) => {
-  const aggregateData = response.aggregate
-  const { fields, records } = aggregateData as ISearchAggregateResult
+  const aggregateData = response.aggregate;
+  const { fields, records } = aggregateData as ISearchAggregateResult;
 
   return new MutableDataFrame({
     name: 'AggregateResponse', // dataframe name
@@ -57,16 +65,15 @@ export const generateAggregateResponse = (response: SearchResult) => {
       return {
         name: field.name,
         type: getSumoToGrafanaType(field.name, field.fieldType),
-        values: records.map(record => formatSumoValues(field.name, record.map[field.name], field.fieldType)),
-      }
+        values: records.map((record) => formatSumoValues(field.name, record.map[field.name], field.fieldType)),
+      };
     }),
-  })
-
-}
+  });
+};
 
 export const generateNonAggregateResponse = (response: SearchResult, previousCountMap: IPreviousCount) => {
-  const nonAggregateData = response.message
-  const { fields, messages } = nonAggregateData as ISearchMessageResult
+  const nonAggregateData = response.message;
+  const { fields, messages } = nonAggregateData as ISearchMessageResult;
 
   previousCountMap.actualMessageCount = messages.length;
   return new MutableDataFrame({
@@ -75,51 +82,49 @@ export const generateNonAggregateResponse = (response: SearchResult, previousCou
       return {
         name: getNonAggregateFieldName(field.name),
         type: getSumoToGrafanaType(field.name, field.fieldType),
-        values: messages.map(message => formatSumoValues(field.name, message.map[field.name], field.fieldType)),
-      }
+        values: messages.map((message) => formatSumoValues(field.name, message.map[field.name], field.fieldType)),
+      };
     }),
     meta: {
-      preferredVisualisationType: 'logs'
-    }
-  })
+      preferredVisualisationType: 'logs',
+    },
+  });
+};
 
-}
+export const generateFullRangeHistogram = (statusObj: ISearchStatus) => {
+  const histohramBuckets = statusObj.histogramBuckets || [];
 
-export const generateFullRangeHistogram = (statusObj : ISearchStatus )=>{
-  const histohramBuckets = statusObj.histogramBuckets || []
-
-  histohramBuckets.sort((bucket1 , bucket2)=>bucket1.startTimestamp - bucket2.startTimestamp);
+  histohramBuckets.sort((bucket1, bucket2) => bucket1.startTimestamp - bucket2.startTimestamp);
 
   return new MutableDataFrame({
     name: 'logsVolumn', // dataframe name
     fields: [
       {
-        name : 'MinBucket',
-        type : FieldType.time,
-        values : histohramBuckets.map(bucket=>bucket.startTimestamp)
+        name: 'MinBucket',
+        type: FieldType.time,
+        values: histohramBuckets.map((bucket) => bucket.startTimestamp),
       },
       {
-        name : 'MaxBucket',
-        type : FieldType.time,
-        values : histohramBuckets.map(bucket=>bucket.startTimestamp + bucket.length),
+        name: 'MaxBucket',
+        type: FieldType.time,
+        values: histohramBuckets.map((bucket) => bucket.startTimestamp + bucket.length),
       },
       {
-        name : 'count',
-        type : FieldType.number,
-        values : histohramBuckets.map(bucket=>bucket.count),
-        config : {
+        name: 'count',
+        type: FieldType.number,
+        values: histohramBuckets.map((bucket) => bucket.count),
+        config: {
           color: {
-              mode: "fixed",
-              fixedColor: "#8e8e8e"
+            mode: 'fixed',
+            fixedColor: '#8e8e8e',
           },
           custom: {
-              drawStyle: "bars",
-              fillColor: "#8e8e8e",
-              fillOpacity: 100,
-          }
-      }
-      }
-    ]
-  })
-
-}
+            drawStyle: 'bars',
+            fillColor: '#8e8e8e',
+            fillOpacity: 100,
+          },
+        },
+      },
+    ],
+  });
+};

--- a/src/services/logDataService/searchQueryDataService.ts
+++ b/src/services/logDataService/searchQueryDataService.ts
@@ -1,101 +1,109 @@
-
-
 import { getBackendSrv } from '@grafana/runtime';
 import { lastValueFrom } from 'rxjs';
 
-import { ISearchAggregateResult, ISearchQueryDataService, ISearchStatus, ISearchCreate, SearchQueryParams, ISearchMessageResult } from './types';
+import {
+  ISearchAggregateResult,
+  ISearchQueryDataService,
+  ISearchStatus,
+  ISearchCreate,
+  SearchQueryParams,
+  ISearchMessageResult,
+} from './types';
 
-
-const SEARCH_JOB_API = '/v1/search/jobs'
+const SEARCH_JOB_API = '/v1/search/jobs';
 
 export class SearchQueryDataService implements ISearchQueryDataService {
-
-  create(
-    searchQueryParams : Omit<SearchQueryParams , 'paginationInfo' | 'types' >  
-  ): Promise<ISearchCreate> {
-
-    const { query , startTime , endTime  , baseUrl , basicAuth } = searchQueryParams
+  create(searchQueryParams: Omit<SearchQueryParams, 'paginationInfo' | 'types'>): Promise<ISearchCreate> {
+    const { query, startTime, endTime, baseUrl, basicAuth } = searchQueryParams;
     const data = {
       query,
-      from : startTime,
-      to : endTime,
-      byReceiptTime: true
-
+      from: startTime,
+      to: endTime,
+      byReceiptTime: true,
     };
-    return  lastValueFrom(getBackendSrv().fetch<ISearchCreate>({
-      method : 'POST',
-      credentials: 'include',
-      headers: {
-        Authorization: basicAuth,
-      },
-      url: baseUrl + SEARCH_JOB_API,
-      data,
-    })).then(response => response.data);
+    return lastValueFrom(
+      getBackendSrv().fetch<ISearchCreate>({
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          Authorization: basicAuth,
+        },
+        url: baseUrl + SEARCH_JOB_API,
+        data,
+      })
+    ).then((response) => response.data);
   }
 
-  status(searchQuerySessionId: string , baseUrl : string , basicAuth:string): Promise<ISearchStatus> {
-    return lastValueFrom(getBackendSrv().fetch<ISearchStatus>({
-      method : 'GET',
-      credentials: 'include',
-      headers: {
-        Authorization: basicAuth,
-      },
-      url: `${baseUrl}${SEARCH_JOB_API}/${searchQuerySessionId}` ,
-    })).then(response => response.data)
+  status(searchQuerySessionId: string, baseUrl: string, basicAuth: string): Promise<ISearchStatus> {
+    return lastValueFrom(
+      getBackendSrv().fetch<ISearchStatus>({
+        method: 'GET',
+        credentials: 'include',
+        headers: {
+          Authorization: basicAuth,
+        },
+        url: `${baseUrl}${SEARCH_JOB_API}/${searchQuerySessionId}`,
+      })
+    ).then((response) => response.data);
   }
 
-  delete(searchQuerySessionId: string , baseUrl : string , basicAuth  :string): Promise<{id : string}>{
-    return lastValueFrom(getBackendSrv().fetch<{id : string}>({
-      method : 'DELETE',
-      credentials: 'include',
-      headers: {
-        Authorization: basicAuth,
-      },
-      url: `${baseUrl}${SEARCH_JOB_API}/${searchQuerySessionId}`,
-    })).then(response => response.data)
+  delete(searchQuerySessionId: string, baseUrl: string, basicAuth: string): Promise<{ id: string }> {
+    return lastValueFrom(
+      getBackendSrv().fetch<{ id: string }>({
+        method: 'DELETE',
+        credentials: 'include',
+        headers: {
+          Authorization: basicAuth,
+        },
+        url: `${baseUrl}${SEARCH_JOB_API}/${searchQuerySessionId}`,
+      })
+    ).then((response) => response.data);
   }
 
   messages(
     searchQuerySessionId: string,
     offset: number,
     length: number,
-    baseUrl : string,
-    basicAuth : string,
+    baseUrl: string,
+    basicAuth: string
   ): Promise<ISearchMessageResult> {
-    return lastValueFrom(getBackendSrv().fetch<ISearchMessageResult>({
-      method : 'GET',
-      credentials: 'include',
-      headers: {
-        Authorization: basicAuth,
-      },
-      params : {
-        offset,
-        limit : length,
-      },
-      url:  `${baseUrl}${SEARCH_JOB_API}/${searchQuerySessionId}/messages`,
-    })).then(response => response.data)
+    return lastValueFrom(
+      getBackendSrv().fetch<ISearchMessageResult>({
+        method: 'GET',
+        credentials: 'include',
+        headers: {
+          Authorization: basicAuth,
+        },
+        params: {
+          offset,
+          limit: length,
+        },
+        url: `${baseUrl}${SEARCH_JOB_API}/${searchQuerySessionId}/messages`,
+      })
+    ).then((response) => response.data);
   }
 
   aggregates(
     searchQuerySessionId: string,
     offset: number,
     length: number,
-    baseUrl : string,
-    basicAuth : string,
+    baseUrl: string,
+    basicAuth: string
   ): Promise<ISearchAggregateResult> {
-
-    return lastValueFrom(getBackendSrv().fetch<ISearchAggregateResult>({
-      method : 'GET',
-      credentials: 'include',
-      headers: {
-        Authorization: basicAuth,
-      },
-      params : {
-        offset,
-        limit : length,
-      },
-      url: `${baseUrl}${SEARCH_JOB_API}/${searchQuerySessionId}/records`,
-    })).then(response => response.data)
+    return lastValueFrom(
+      getBackendSrv().fetch<ISearchAggregateResult>({
+        method: 'GET',
+        credentials: 'include',
+        headers: {
+          Authorization: basicAuth,
+        },
+        params: {
+          offset,
+          limit: length,
+        },
+        url: `${baseUrl}${SEARCH_JOB_API}/${searchQuerySessionId}/records`,
+      })
+    ).then((response) => response.data);
   }
 }
 

--- a/src/services/logDataService/types.ts
+++ b/src/services/logDataService/types.ts
@@ -1,112 +1,101 @@
 import type { Observable } from 'rxjs';
 import { RunSearchActionType, SearchQueryType, SearchStatus } from './constants';
 
-
 export interface ISearchQueryDataService {
-    create: (
-        searchQueryParams: Omit<SearchQueryParams, 'paginationInfo' | 'types'>
-    ) => Promise<ISearchCreate>;
-    status: (searchQuerySessionId: string, baseUrl: string, basicAuth: string) => Promise<ISearchStatus>;
-    delete: (searchQuerySessionId: string, baseUrl: string, basicAuth: string) => Promise<any>;
-    messages: (
-        searchQuerySessionId: string,
-        offset: number,
-        length: number,
-        baseUrl: string,
-        basicAuth: string,
-    ) => Promise<ISearchMessageResult>;
-    aggregates: (
-        searchQuerySessionId: string,
-        offset: number,
-        length: number,
-        baseUrl: string,
-        basicAuth: string,
-    ) => Promise<ISearchAggregateResult>;
-}
-
-export interface ISearchCreate {
-    id: string;
-}
-
-
-export type SearchStatusFilter = (
-    searchObservable: Observable<ISearchStatus>,
-) => Observable<ISearchStatus>;
-
-
-
-export interface SearchPaginationInfo {
-    offset: number;
-    length: number;
-    hasMore?: boolean;
-    totalResults?: number;
-}
-
-export interface SearchQueryParams {
-    types: SearchQueryType[];
-    query: string;
-    startTime: number,
-    endTime: number,
-    timeZone?: string;
-    baseUrl: string,
-    basicAuth: string,
-    paginationInfo: SearchPaginationInfo;
-}
-
-export interface RunSearchAction {
-    type: RunSearchActionType;
-    payload?: any;
-}
-
-
-export interface IHistogramBucket{
-    startTimestamp : number,
-    length : number,
-    count : number
-}
-
-export interface ISearchStatus {
-    state: SearchStatus;
-    messageCount?: number;
-    histogramBuckets : IHistogramBucket[] 
-    recordCount?: number;
-    pendingErrors?: any[];
-    pendingWarnings?: any[];
-}
-
-export interface IField {
-    name: string,
-    fieldType: string,
-    keyField: boolean
-}
-
-export interface IRecords {
-    map: Record<string, string>
-}
-
-export interface ISearchAggregateResult {
-    fields: IField[];
-    records: IRecords[];
-}
-
-export interface ISearchMessageResult {
-    fields: IField[];
-    messages: IRecords[];
-}
-
-export interface SearchResult {
-    status: ISearchStatus;
-    // These keys should match SearchQueryType enum
-    message?: ISearchMessageResult;
-    aggregate?: ISearchAggregateResult;
-}
-
-
-export type RetrievePageFunction = (
-    sessionId: string,
+  create: (searchQueryParams: Omit<SearchQueryParams, 'paginationInfo' | 'types'>) => Promise<ISearchCreate>;
+  status: (searchQuerySessionId: string, baseUrl: string, basicAuth: string) => Promise<ISearchStatus>;
+  delete: (searchQuerySessionId: string, baseUrl: string, basicAuth: string) => Promise<any>;
+  messages: (
+    searchQuerySessionId: string,
     offset: number,
     length: number,
     baseUrl: string,
     basicAuth: string
-) => Promise<any>;
+  ) => Promise<ISearchMessageResult>;
+  aggregates: (
+    searchQuerySessionId: string,
+    offset: number,
+    length: number,
+    baseUrl: string,
+    basicAuth: string
+  ) => Promise<ISearchAggregateResult>;
+}
 
+export interface ISearchCreate {
+  id: string;
+}
+
+export type SearchStatusFilter = (searchObservable: Observable<ISearchStatus>) => Observable<ISearchStatus>;
+
+export interface SearchPaginationInfo {
+  offset: number;
+  length: number;
+  hasMore?: boolean;
+  totalResults?: number;
+}
+
+export interface SearchQueryParams {
+  types: SearchQueryType[];
+  query: string;
+  startTime: number;
+  endTime: number;
+  timeZone?: string;
+  baseUrl: string;
+  basicAuth: string;
+  paginationInfo: SearchPaginationInfo;
+}
+
+export interface RunSearchAction {
+  type: RunSearchActionType;
+  payload?: any;
+}
+
+export interface IHistogramBucket {
+  startTimestamp: number;
+  length: number;
+  count: number;
+}
+
+export interface ISearchStatus {
+  state: SearchStatus;
+  messageCount?: number;
+  histogramBuckets: IHistogramBucket[];
+  recordCount?: number;
+  pendingErrors?: any[];
+  pendingWarnings?: any[];
+}
+
+export interface IField {
+  name: string;
+  fieldType: string;
+  keyField: boolean;
+}
+
+export interface IRecords {
+  map: Record<string, string>;
+}
+
+export interface ISearchAggregateResult {
+  fields: IField[];
+  records: IRecords[];
+}
+
+export interface ISearchMessageResult {
+  fields: IField[];
+  messages: IRecords[];
+}
+
+export interface SearchResult {
+  status: ISearchStatus;
+  // These keys should match SearchQueryType enum
+  message?: ISearchMessageResult;
+  aggregate?: ISearchAggregateResult;
+}
+
+export type RetrievePageFunction = (
+  sessionId: string,
+  offset: number,
+  length: number,
+  baseUrl: string,
+  basicAuth: string
+) => Promise<any>;

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -1,53 +1,48 @@
-import { FieldType } from "@grafana/data";
+import { FieldType } from '@grafana/data';
 
-export const enum SumoQueryType{
-    LogsAggregate = 'LogsAggregate',
-    LogsNonAggregate = 'LogsNonAggregate',
-    Metrics = 'Metrics'
+export const enum SumoQueryType {
+  LogsAggregate = 'LogsAggregate',
+  LogsNonAggregate = 'LogsNonAggregate',
+  Metrics = 'Metrics',
 }
 
-export const SumoToGrafanaTypeMap : Record<string , FieldType> = {
-    int : FieldType.number,
-    double : FieldType.number,
-    string : FieldType.string,
-    long : FieldType.number
-}
+export const SumoToGrafanaTypeMap: Record<string, FieldType> = {
+  int: FieldType.number,
+  double: FieldType.number,
+  string: FieldType.string,
+  long: FieldType.number,
+};
 
-export const SumoToGrafanaFieldName : Record< string ,string > = {
-    _loglevel : 'level',
-    _messagetime : 'Time'
-}
+export const SumoToGrafanaFieldName: Record<string, string> = {
+  _loglevel: 'level',
+  _messagetime: 'Time',
+};
 
+const TimeFields = ['_timeslice', '_receipttime', '_messagetime', '_start_time', '_end_time'];
 
-const TimeFields = ['_timeslice' , '_receipttime' , '_messagetime', '_start_time', '_end_time' ]
+export const getSumoToGrafanaType = (fieldName: string, fieldType: string): FieldType => {
+  if (TimeFields.includes(fieldName)) {
+    return FieldType.time;
+  }
+  return SumoToGrafanaTypeMap[fieldType] || FieldType.string;
+};
 
-export const getSumoToGrafanaType  = (fieldName : string , fieldType : string) : FieldType =>{
-    if(TimeFields.includes(fieldName)){
-        return FieldType.time
-    }
-    return SumoToGrafanaTypeMap[fieldType] || FieldType.string;
-}
+export const getNonAggregateFieldName = (fieldName: string): string => {
+  return SumoToGrafanaFieldName[fieldName] || fieldName;
+};
 
+export const formatSumoValues = (name: string, value: string, type: string) => {
+  if (name === '_loglevel') {
+    return (value || '').toLocaleLowerCase();
+  }
 
-export const getNonAggregateFieldName = (fieldName : string) : string =>{
-    return SumoToGrafanaFieldName[fieldName] || fieldName
-}   
+  if (type === 'int' || type === 'double' || type === 'long') {
+    return Number(value);
+  }
 
-export const formatSumoValues = (name : string, value : string, type : string)=>{
+  return value;
+};
 
-    if(name === '_loglevel'){
-        return (value || '').toLocaleLowerCase()
-    }
-
-    if(type === 'int' || type === 'double' || type==='long'){
-        return Number(value)
-    }
-
-    return value
-}
-
-
-export const isLogsQuery = (type :  SumoQueryType | undefined)=>{
-    return type === SumoQueryType.LogsAggregate || type === SumoQueryType.LogsNonAggregate
-}
-
+export const isLogsQuery = (type: SumoQueryType | undefined) => {
+  return type === SumoQueryType.LogsAggregate || type === SumoQueryType.LogsNonAggregate;
+};

--- a/src/types/metricsApi.types.ts
+++ b/src/types/metricsApi.types.ts
@@ -82,5 +82,5 @@ export interface MetricsQuery {
 
 export interface SumoQuery extends DataQuery {
   queryText?: string;
-  type?: SumoQueryType
+  type?: SumoQueryType;
 }

--- a/src/utils/labels.utils.ts
+++ b/src/utils/labels.utils.ts
@@ -1,7 +1,8 @@
 import { MetricResultDetailsDimensions } from '../types/metricsApi.types';
 
 export function dimensionsToLabelSuffix(dimensions: MetricResultDetailsDimensions[]) {
-  return dimensions.filter(({ key, legend }) => legend && key !== 'metric')
+  return dimensions
+    .filter(({ key, legend }) => legend && key !== 'metric')
     .map(({ key, value }) => `${key}=${value}`)
     .join(' ');
 }


### PR DESCRIPTION
Currently test connection would use metadata catalog API, which is not externally enabled. This creates a lot of problems for people trying to use our plugin.

I've replaced test connection strategy with running log query `* | count` for the last 15 minutes. This should in general verify if connection can be established.