### PR TITLE
Display errors even if some data is returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.1 
+
+### Fixes:
+- Fix displaying error for invalid queries even if other returns data
+
+
 ## 1.1.0 Sumo Grafana Datasource Plugin
 
 ### Highlights:

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -417,7 +417,6 @@ describe('placeholder test', () => {
 
     it('should handle metrics warning for multiple queries', async () => {
       const mockedFetch = getBackendSrv().fetch as jest.Mock;
-      // const queryMockResponse();
       const mockResponse = queryMockResponse();
       mockedFetch.mockReturnValue(
         of({
@@ -435,10 +434,6 @@ describe('placeholder test', () => {
             ],
             response: [
               mockResponse.response[0],
-              {
-                rowId: 'B',
-                results: [],
-              },
             ],
           },
         })


### PR DESCRIPTION
Errors for invalid queries were displayed only if no data was returned (for any of the queries).

After these changes we display errors for invalid queries even is some data is returned for other queries.

<img width="1728" alt="Screenshot 2023-09-04 at 11 36 16" src="https://github.com/SumoLogic-Labs/sumologic-grafana-datasource/assets/100689160/58ac0027-bf17-4724-8295-4ad7b5f5691d">
<img width="1728" alt="Screenshot 2023-09-04 at 11 37 38" src="https://github.com/SumoLogic-Labs/sumologic-grafana-datasource/assets/100689160/6998faa1-a9ab-4486-85e8-7e96c9f7b64f">
